### PR TITLE
Feat/libraryinfo get

### DIFF
--- a/stopMoving/books/management/commands/seed_book_dummy.py
+++ b/stopMoving/books/management/commands/seed_book_dummy.py
@@ -1,0 +1,95 @@
+# books/management/commands/seed_book_dummy.py
+# Books 테이블의 더미 데이터를 생성하는 커맨드
+import random
+from itertools import cycle, islice
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+from django.db import transaction
+
+from bookinfo.models import BookInfo
+from library.models import Library
+from django.contrib.auth import get_user_model
+
+from books.models import Book
+
+class Command(BaseCommand):
+    help = "Book 테이블에 더미데이터를 삽입합니다. (중간테이블: Library × BookInfo)"
+
+    # python manage/run_with_tunnel.py 커맨드 실행 시 추가 옵션을 받을 수 있도록 함(인자 정의)
+    def add_arguments(self, parser):
+        parser.add_argument("--count", type=int, default=100, help="생성 개수 (기본 100)")
+        parser.add_argument("--status", type=str, default="half", choices=["half", "available", "picked"],
+                            help="상태 분포: half(절반씩), available(전부), picked(전부)")
+        parser.add_argument("--library-ids", type=str, help="지정 라이브러리 id들(쉼표로 구분). 없으면 전체에서 랜덤")
+        parser.add_argument("--only-priced", action="store_true",
+                            help="정가가 있는 BookInfo만 사용")
+        
+    def handle(self, *args, **opts):
+        count = opts["count"]
+        status_mode = opts["status"]
+        only_priced = opts["only_priced"]
+
+        # 도서관 후보 선택
+        if opts.get("library_ids"): # 지정된 도서관 ID가 있으면 해당 라이브러리만 사용
+            ids = [int(x) for x in opts["library_ids"].split(",") if x.strip()]
+            libraries = list(Library.objects.filter(id__in=ids))
+        else:   # 지정된 도서관이 없으면 전체 라이브러리에서 랜덤 선택
+            libraries = list(Library.objects.all())
+
+        if not libraries:   # 라이브러리가 없으면 에러 메시지 출력 후 종료
+            self.stderr.write(self.style.ERROR("Library 데이터가 없습니다. 먼저 라이브러리를 생성하세요."))
+            return
+
+        # BookInfo 후보 선택
+        bookinfo_qs = BookInfo.objects.all()
+        if only_priced: # BookInfo에서 정가가 있는 항목만 필터링
+            bookinfo_qs = bookinfo_qs.exclude(regular_price__isnull=True)
+        bookinfos = list(bookinfo_qs)
+
+        if not bookinfos:   # BookInfo가 없으면 에러 메시지 출력 후 종료
+            self.stderr.write(self.style.ERROR("BookInfo 데이터가 없습니다. 먼저 BookInfo를 적재하세요."))
+            return
+
+        # donor_user 후보 
+        # 1~7 사이의 유저 ID를 가진 유저들 중에서 랜덤으로 선택
+        User = get_user_model()
+        user_ids = list(User.objects.filter(id__in=range(1, 8)).values_list("id", flat=True))
+
+        # status 분포 - available, picked가 절반씩 나오도록 설정
+        if status_mode == "half":
+            status_cycle = cycle(["AVAILABLE", "PICKED"])
+        elif status_mode == "available":
+            status_cycle = cycle(["AVAILABLE"])
+        else:
+            status_cycle = cycle(["PICKED"])
+
+        # 객체 생성
+        now = timezone.now()
+        objs: list[Book] = []
+        for i in range(count):
+            lib = random.choice(libraries)
+            bi = random.choice(bookinfos)
+
+            # donation_date/expire_date를 명시적으로 세팅 (bulk_create는 save()를 호출하지 않음)
+            # 기증일: 현재 시각, 만료일: 기증일로부터 30일 후
+            donation_date = now
+            expire_date = donation_date + timedelta(days=30)
+
+            obj = Book(
+                library=lib,
+                isbn_id=bi.isbn,                 # FK(to_field="isbn")이므로 _id에 문자열 ISBN 주입
+                regular_price=bi.regular_price,  # BookInfo의 정가 복사
+                donation_date=donation_date,
+                expire_date=expire_date,
+                status=next(status_cycle),
+                donor_user_id=random.choice(user_ids),  # 1~7 사이 랜덤 유저 FK로 할당
+            )
+            objs.append(obj)
+
+        # 대량 삽입
+        with transaction.atomic():
+            Book.objects.bulk_create(objs, batch_size=500)
+
+        self.stdout.write(self.style.SUCCESS(f"완료: Book 더미 {len(objs)}건 생성"))

--- a/stopMoving/config/urls.py
+++ b/stopMoving/config/urls.py
@@ -37,5 +37,6 @@ urlpatterns = [
     path('bookinfo/', include('bookinfo.urls')), # bookinfo 앱의 URL 포함
     path('accounts/', include('accounts.urls')), # accounts 앱의 URL 포함
     path('books/', include('books.urls')), # books 앱의 URL 포함
+    path('library/', include('library.urls')), # library 앱의 URL 포함
     path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
 ]

--- a/stopMoving/library/exceptions.py
+++ b/stopMoving/library/exceptions.py
@@ -1,0 +1,13 @@
+# library/exceptions.py
+# library 앱의 커스텀 예외 처리
+from rest_framework.exceptions import APIException
+
+class LibraryNotFound(APIException):
+    status_code = 404
+    default_detail = "도서관을 찾을 수 없습니다."
+    default_code = "LIBRARY_404"
+
+class BookNotFound(APIException):
+    status_code = 404
+    default_detail = "해당 도서관에 구매 가능한(AVAILABLE) 도서가 없습니다."
+    default_code = "BOOK_404"

--- a/stopMoving/library/serializer.py
+++ b/stopMoving/library/serializer.py
@@ -1,7 +1,22 @@
 from rest_framework import serializers
 from .models import Library
+from bookinfo.models import BookInfo
+from books.models import Book
 
 class LibraryInfoSerializer(serializers.ModelSerializer):
     class Meta:
         model = Library
         fields = ['id', 'name', 'address', 'contact', 'closed_days', 'hours_of_use', 'sns']
+
+class LibraryHoldingItemSerializer(serializers.ModelSerializer):
+    title = serializers.CharField(source="isbn.title")
+    author = serializers.CharField(source="isbn.author")
+    publisher = serializers.CharField(source="isbn.publisher")
+    cover = serializers.URLField(source="isbn.cover_url", allow_blank=True, required=False)
+
+    class Meta:
+        model = Book
+        fields = ["title", "author", "publisher", "cover"]
+        extra_kwargs = {
+            "cover": {"help_text": "표지 이미지 URL"}
+        }

--- a/stopMoving/library/serializer.py
+++ b/stopMoving/library/serializer.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+from .models import Library
+
+class LibraryInfoSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Library
+        fields = ['id', 'name', 'address', 'contact', 'closed_days', 'hours_of_use', 'sns']

--- a/stopMoving/library/urls.py
+++ b/stopMoving/library/urls.py
@@ -1,0 +1,7 @@
+# libraryapp/urls.py
+from django.urls import path
+from .views import LibraryDetailAPIView
+
+urlpatterns = [
+    path("libraries/<int:library_id>/", LibraryDetailAPIView.as_view(), name="library-detail"),
+]

--- a/stopMoving/library/urls.py
+++ b/stopMoving/library/urls.py
@@ -1,7 +1,8 @@
 # libraryapp/urls.py
 from django.urls import path
-from .views import LibraryDetailAPIView
+from .views import LibraryDetailAPIView, LibraryBooksAPIView
 
 urlpatterns = [
-    path("libraries/<int:library_id>/", LibraryDetailAPIView.as_view(), name="library-detail"),
+    path("libraries/<int:library_id>/", LibraryDetailAPIView.as_view(), name="library-detail"), # 도서관 상세 정보 조회
+    path('<int:library_id>/books/', LibraryBooksAPIView.as_view(), name='library-books'), # 도서관별 책 목록 조회
 ]

--- a/stopMoving/library/views.py
+++ b/stopMoving/library/views.py
@@ -4,10 +4,14 @@ from django.shortcuts import get_object_or_404, render
 # 도서관 정보 조회 api
 from rest_framework.views import APIView
 from rest_framework.response import Response
-from rest_framework import status
-from .serializer import LibraryInfoSerializer
+from rest_framework import status, permissions
+
+from .serializer import LibraryHoldingItemSerializer, LibraryInfoSerializer
 from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
 from .models import Library
+from books.models import Book
+from .exceptions import LibraryNotFound, BookNotFound
 
 class LibraryDetailAPIView(APIView):
     @swagger_auto_schema(
@@ -18,3 +22,42 @@ class LibraryDetailAPIView(APIView):
         lib = get_object_or_404(Library, pk=library_id)
         serializer = LibraryInfoSerializer(lib)
         return Response(serializer.data, status=status.HTTP_200_OK)
+    
+class LibraryBooksAPIView(APIView):
+    permission_classes = [permissions.AllowAny]
+
+    @swagger_auto_schema(
+        operation_description="도서관의 책 목록 조회",
+        manual_parameters=[ ],
+        responses={
+            200: "성공",
+            400: "잘못된 요청",
+            404: "도서관/도서 없음 (LIBRARY_404 / BOOK_404)",
+        },
+    )
+    def get(self, request, library_id: int):
+        # 1) 도서관 존재 확인 (없으면 404 커스텀)
+        library = Library.objects.filter(pk=library_id).first()
+        if not library:
+            raise LibraryNotFound
+        
+        # 2) 상태가 AVAILABLE인 책만 필터링 + BookInfo 조인
+        qs = (
+            Book.objects
+            .filter(library_id=library.id, status="AVAILABLE")  # 대문자 주의
+            .select_related("isbn")  # Book.isbn(FK) → BookInfo
+            .only(
+                "id", "status",
+                "isbn__isbn", "isbn__title", "isbn__author",
+                "isbn__publisher", "isbn__cover_url"
+            )
+            .order_by("-id")
+        )
+
+        # 3) 책 없음 → 404 커스텀
+        if not qs.exists():
+            raise BookNotFound
+
+        # 4) 직렬화 & 반환 (전체 목록 그대로)
+        data = LibraryHoldingItemSerializer(qs, many=True).data
+        return Response(data, status=status.HTTP_200_OK)

--- a/stopMoving/library/views.py
+++ b/stopMoving/library/views.py
@@ -1,3 +1,20 @@
-from django.shortcuts import render
+from django.shortcuts import get_object_or_404, render
 
 # Create your views here.
+# 도서관 정보 조회 api
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+from .serializer import LibraryInfoSerializer
+from drf_yasg.utils import swagger_auto_schema
+from .models import Library
+
+class LibraryDetailAPIView(APIView):
+    @swagger_auto_schema(
+        operation_description="도서관 상세 정보 조회",
+        responses={200: '성공', 404: '도서관 없음'}
+    )
+    def get(self, request, library_id: int):
+        lib = get_object_or_404(Library, pk=library_id)
+        serializer = LibraryInfoSerializer(lib)
+        return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
## 개요
- 도서관 상세 정보 조회 API 추가
- 도서관별 보유 도서 목록(AVAILABLE만) + 책 메타 정보 반환 API 추가
- Book 테이블 더미데이터 시드 커맨드 추가(100건, donor_user 1~7 랜덤)

## 변경사항
1) 도서관 상세 정보 조회
- Endpoint: GET /api/libraries/{library_id}
- 반환 데이터: name, address, contact, closed_days, hours_of_use, sns
- '동작구 통합도서관' 홈페이지와의 데이터 차이가 있어 추후 수정이 필요할 것 같습니다

2) 도서관별 책 목록 조회
- Endpoint: GET /api/libraries/{library_id}/books/
- 상태가 available(수령 가능)인 책 목록만 반환
- 반환 데이터(책 상세정보): title, author, publisher, cover

3) Book 테이블 더미데이터 생성
- books/management/commands/seed_book_dummy.py에 작성
- Library/BookInfo 랜덤 조합으로 100건 생성
- 기증자는 id가 1~7인 유저들 중 랜덤으로 설정