### PR TITLE
fix: 가중치 부여하여 mode에 따른 추천 결과 분산

### DIFF
--- a/stopMoving/config/settings.py
+++ b/stopMoving/config/settings.py
@@ -34,7 +34,12 @@ VECTOR_PICKLE_PATH = os.path.join(VECTOR_DATA_DIR, "vectorizer.pkl")
 # 수정: 0.7 -> 0.85
 RECOMMEND_ALPHA = 0.85 # 통합 = a*설문 + (1-a)+활동
 ACTIVITY_EMA_BETA = 0.8 # 활동벡터 EMA: new = b*old + (1-b)*new_book
-
+# 추천 튜닝 파라미터
+RECOMMEND_MMR_POOL = 100 # 초기 상위 N개 후보에서 리랭킹
+RECOMMEND_MMR_LAMBDA = 0.3 # 연관도 ↑, 분포 ↓
+RECOMMEND_SURVEY_BOOST = 0.25 # combined mode: 설문 벡터 가중치
+RECOMMEND_RECENT_BOOST = 0.30 # activity mode: 최근 픽업 벡터 가중치
+RECOMMEND_RECENT_N = 3 # 최근 N권 평균으로 최근 벡터 구성
 secret_file = os.path.join(BASE_DIR, 'secrets.json') 
 
 with open(secret_file) as f:

--- a/stopMoving/preferences/services/recommend.py
+++ b/stopMoving/preferences/services/recommend.py
@@ -3,34 +3,84 @@ from typing import List, Tuple
 import numpy as np
 from scipy import sparse
 
-def cosine_topk(user_csr, items, k=5):
-    if user_csr is None:
-        return []
-    # ✅ (isbn, csr) 2-튜플만 깨끗하게 사용
+def _clean_items(items):
     cleaned = []
     for t in items:
         if not (isinstance(t, (tuple, list)) and len(t) == 2):
             continue
         isbn, csr = t
-        # csr 처럼 보이는지 최종 확인
-        if csr is None or not hasattr(csr, "shape"):
+        if csr is None or not hasattr(csr, "shape") or getattr(csr, "nnz", 0) == 0:
             continue
         cleaned.append((isbn, csr))
-    if not cleaned:
-        return []
+    return cleaned
 
-    mats = sparse.vstack([v for _, v in cleaned])
-    # TF-IDF는 norm=l2라 dot = cosine
-    scores = (mats @ user_csr.T).toarray().ravel()
-    if scores.size == 0:
+def cosine_topk(user_csr, items, k=5):
+    if user_csr is None:
         return []
-
+    cleaned = _clean_items(items)
+    if not cleaned: return []
+    M = sparse.vstack([v for _, v in cleaned])
+    scores = (M @ user_csr.T).toarray().ravel()
     idx = np.argsort(-scores)[:k]
-    out = []
-    for i in idx:
-        try:
-            out.append((cleaned[i][0], float(scores[i])))
-        except Exception:
-            # 인덱싱 오류 등 방어
+    return [(cleaned[i][0], float(scores[i])) for i in idx]
+
+# (cleaned_items, M, base_scores) 반환
+def cosine_scores(user_csr, items):
+    cleaned = _clean_items(items)
+    if not cleaned:
+        return [], None, np.array([])
+    M = sparse.vstack([v for _, v in cleaned])
+    scores = (M @ user_csr.T).toarray().ravel()
+    return cleaned, M, scores
+
+# combined/activity 모드에 따라 추가 점수 부여
+def apply_boosts(mode: str,
+                 M: sparse.csr_matrix,
+                 base_scores: np.ndarray,
+                 survey_vec: sparse.csr_matrix | None,
+                 recent_vec: sparse.csr_matrix | None,
+                 survey_w: float = 0.25,
+                 recent_w: float = 0.30) -> np.ndarray:
+    scores = base_scores.copy()
+    if mode == "combined" and survey_vec is not None and getattr(survey_vec, "nnz", 0) > 0:
+        scores += survey_w * (M @ survey_vec.T).toarray().ravel()
+    if mode == "activity" and recent_vec is not None and getattr(recent_vec, "nnz", 0) > 0:
+        scores += recent_w * (M @ recent_vec.T).toarray().ravel()
+    return scores
+
+def mmr_rerank(M: sparse.csr_matrix,
+               scores: np.ndarray,
+               k: int = 5,
+               pool: int = 100,
+               lam: float = 0.3) -> List[int]:
+    if M is None or M.shape[0] == 0:
+        return []
+    # 후보: base score 상위인 pool개
+    top_idx = np.argsort(-scores)[:min(pool, M.shape[0])]
+    M_pool = M[top_idx] # (P, D)
+    rel = scores[top_idx] # (P, )
+
+    selected = []
+    cand_mask = np.ones(M_pool.shape[0], dtype=bool)
+
+    for _ in range(min(k, M_pool.shape[0])):
+        if not selected:
+            i = int(np.argmax(rel))
+            selected.append(i)
+            cand_mask[i] = False
             continue
-    return out
+        # 현재 선택된 것과의 유사도 중 최대값 계싼
+        M_sel = M_pool[selected] # (s, D)
+        # (P, D) @ (D, s) -> (P, s) -> 각 후보별 최대 유사도
+        sims = (M_pool @ M_sel.T).toarray()
+        max_sim = sims.max(axis=1) # (P, )
+        mmr = lam * rel - (1 - lam) * max_sim
+        mmr[~cand_mask] = -1e9 # 이미 뽑힌 후보는 제외
+        i = int(np.argmax(mmr))
+        if not cand_mask[i]:
+            break
+        selected.append(i)
+        cand_mask[i] = False
+
+    # pool 내 인덱스를 원본 인덱스로 환산
+    return [int(top_idx[i]) for i in selected]

--- a/stopMoving/preferences/views.py
+++ b/stopMoving/preferences/views.py
@@ -15,7 +15,7 @@ from .services.keyword_extractor import extract_keywords_from_books
 from preferences.services.embeddings import(
     load_vectorizer, serialize_sparse, deserialize_sparse, weighted_sum, l2_normalize
 )
-from preferences.services.recommend import cosine_topk
+from preferences.services.recommend import cosine_topk, cosine_scores, apply_boosts, mmr_rerank
 from django.conf import settings
 from django.utils import timezone
 import numpy as np
@@ -110,18 +110,16 @@ class RecommendView(APIView):
         mode = (request.query_params.get("mode") or "combined").strip().lower()
         if mode not in ("combined", "activity"):
             mode = "combined"
+
         ui = UserInfo.objects.get(user=request.user)
-
-        if mode == "combined":
-            vec_json = ui.preference_vector
-        else:
-            vec_json = ui.preference_vector_activity
-
+        vec_json = ui.preference_vector if mode == "combined" else ui.preference_vector_activity
         user_vec = deserialize_sparse(vec_json)
-
-        if user_vec is None:
+        if user_vec is None or getattr(user_vec, "nnz", 0) == 0:
             return Response({"mode": mode, "results": []}, status=status.HTTP_200_OK)
-        
+
+        # 로딩 후 정규화(안전)
+        user_vec = l2_normalize(user_vec)
+
         # 본인이 기증/수령한 책 제외
         exclude_isbns = set(
             UserBook.objects.filter(user=request.user)
@@ -129,45 +127,125 @@ class RecommendView(APIView):
         )
 
         # 후보군 로드
-        items, bad_isbns = [], []
-        bad_shapes = 0
-        for bi in (BookInfo.objects.exclude(isbn__in=exclude_isbns).exclude(vector__isnull=True).iterator()):
+        items, bad_isbns, bad_shapes = [], [], 0
+        for bi in (BookInfo.objects
+                   .exclude(isbn__in=exclude_isbns)
+                   .exclude(vector__isnull=True)
+                   .iterator()):
             csr = deserialize_sparse(bi.vector)
             if csr is None or getattr(csr, "nnz", 0) == 0:
                 bad_isbns.append(bi.isbn)
                 continue
             pair = (bi.isbn, csr)
-            # ✅ 형태 검증: (isbn, csr) 2-튜플만 허용
             if not (isinstance(pair, (tuple, list)) and len(pair) == 2):
                 bad_shapes += 1
                 continue
             items.append(pair)
 
-        top = cosine_topk(user_vec, items, k=5)
-        score_map = {isbn: s for isbn, s in top}
-        books = list(BookInfo.objects.filter(isbn__in=score_map.keys()))
-        books.sort(key=lambda b: -score_map[b.isbn])
+        # base scores
+        cleaned, M, base_scores = cosine_scores(user_vec, items)
+        if not cleaned:
+            return Response({"mode": mode, "results": []}, status=status.HTTP_200_OK)
 
-        results = [{
-            "isbn": b.isbn,
-            "title": b.title,
-            "author": b.author,
-            "cover_url": b.cover_url,
-            "category": b.category,
-            "score": round(score_map[b.isbn], 6),
+        # 모드별 부스트용 벡터
+        sv = deserialize_sparse(getattr(ui, "preference_vector_survey", None))
 
-        } for b in books]
+        recent_vec = None
+        if mode == "activity":
+            # 최근 N권 평균 벡터
+            n = getattr(settings, "RECOMMEND_RECENT_N", 3)
+            recent_books = (UserBook.objects
+                            .filter(user=request.user)
+                            .order_by("-created_at")
+                            .select_related("book__isbn")[:n])
+            vs = []
+            for ub in recent_books:
+                bv = deserialize_sparse(getattr(ub.book.isbn, "vector", None))
+                if bv is not None and getattr(bv, "nnz", 0) > 0:
+                    vs.append(bv)
+            if vs:
+                s = vs[0].copy()
+                for v in vs[1:]:
+                    s = s + v
+                recent_vec = l2_normalize(s * (1.0 / len(vs)))
+
+        # 쿼리 파라미터로 부스트 가중치 변경 가능
+        survey_w = float(request.query_params.get("survey_boost") or getattr(settings, "RECOMMEND_SURVEY_BOOST", 0.25))
+        recent_w = float(request.query_params.get("recent_boost") or getattr(settings, "RECOMMEND_RECENT_BOOST", 0.30))
+
+        boosted = apply_boosts(
+            mode=mode,
+            M=M,
+            base_scores=base_scores,
+            survey_vec=sv,
+            recent_vec=recent_vec,
+            survey_w=survey_w,
+            recent_w=recent_w,
+        )
+
+        # MMR 리랭킹 (선택된 "순서" 그대로 결과에 반영)
+        use_div = (request.query_params.get("diversity") or "1").strip().lower() in ("1", "true", "yes", "y")
+        pool = int(request.query_params.get("pool") or getattr(settings, "RECOMMEND_MMR_POOL", 100))
+        lam = float(request.query_params.get("lambda") or getattr(settings, "RECOMMEND_MMR_LAMBDA", 0.3))
+
+        if use_div:
+            sel_idx = mmr_rerank(M, boosted, k=5, pool=pool, lam=lam)
+            ordered_isbns = [cleaned[i][0] for i in sel_idx]            # ← MMR 순서 보존
+            ordered_scores = [float(boosted[i]) for i in sel_idx]
+        else:
+            idx = np.argsort(-boosted)[:5]
+            ordered_isbns = [cleaned[i][0] for i in idx]
+            ordered_scores = [float(boosted[i]) for i in idx]
+
+        # 한 번에 가져오고, "선택된 순서"대로 결과 구성
+        books_by_isbn = {b.isbn: b for b in BookInfo.objects.filter(isbn__in=ordered_isbns)}
+        results = []
+        for isbn, sc in zip(ordered_isbns, ordered_scores):
+            b = books_by_isbn.get(isbn)
+            if not b:
+                continue
+            results.append({
+                "isbn": b.isbn,
+                "title": b.title,
+                "author": b.author,
+                "cover_url": b.cover_url,
+                "category": b.category,
+                "score": round(sc, 6),
+            })
 
         response_data = {"mode": mode, "results": results}
-        
+
+        # 디버깅 상세
         dbg = (request.query_params.get("debug") or "").strip().lower()
         if dbg in ("1", "true", "yes", "y"):
+            # 원본 벡터 대비/코사인 유사도
+            u_comb = deserialize_sparse(ui.preference_vector)
+            u_act  = deserialize_sparse(ui.preference_vector_activity)
+            def _cos(u, v):
+                if u is None or v is None or getattr(u, "nnz", 0) == 0 or getattr(v, "nnz", 0) == 0:
+                    return 0.0
+                num = float((u @ v.T).toarray()[0, 0])
+                du  = float(np.sqrt((u.data**2).sum()))
+                dv  = float(np.sqrt((v.data**2).sum()))
+                return num / (du*dv) if du > 0 and dv > 0 else 0.0
             response_data["debug"] = {
-                "user_vec_digest": _csr_digest(user_vec),
-                "candidate_count": len(items),
+                "candidate_count": len(cleaned),
                 "exclude_count": len(exclude_isbns),
+                "mmr_pool": pool,
+                "mmr_lambda": lam,
+                "used_diversity": use_div,
+                "used_vec_digest": _csr_digest(user_vec),
+                "raw_combined_digest": _csr_digest(u_comb),
+                "raw_activity_digest": _csr_digest(u_act),
+                "combined_vs_activity_cosine": round(_cos(u_comb, u_act), 6),
+                "survey_vec_used": bool(sv is not None and getattr(sv, "nnz", 0) > 0),
+                "recent_vec_used": bool(recent_vec is not None and getattr(recent_vec, "nnz", 0) > 0),
+                "survey_boost": survey_w,
+                "recent_boost": recent_w,
             }
             if bad_isbns:
                 response_data["debug"]["skipped_bad_vectors"] = bad_isbns[:20]
+            if bad_shapes:
+                response_data["debug"]["bad_shape_count"] = bad_shapes
 
         return Response(response_data, status=status.HTTP_200_OK)


### PR DESCRIPTION
- settings.py
  - 가중치 부여를 위한 튜닝 파라미터값 설정
- preferences/services/recommend.py
  - apply_boosts 함수를 통해 모드에 따른 추가점수 계산
- preferences/views.py
  - recommendview api에 모드별 가중치 벡터, mmr 리랭킹 반영